### PR TITLE
[AWN-104308] rename(.github): CODEOWNERs to use Brewmasters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rtkwlf/rnd_brewmasters


### PR DESCRIPTION
Rename brewmasters team from sre to brewmasters